### PR TITLE
Add dungeon item stats, update special enchantments

### DIFF
--- a/src/constants/misc.js
+++ b/src/constants/misc.js
@@ -75,7 +75,11 @@ module.exports = {
         'Spiked Hook 6',
         'Spiked Hook VI',
         'Dragon Hunter 5',
-        'Dragon Hunter V'
+        'Dragon Hunter V',
+        'Feather Falling 10',
+        'Feather Falling X',
+        'Infinite Quiver 10',
+        'Infinite Quiver X'
     ],
 
     // Player stats on a completely new profile

--- a/src/lib.js
+++ b/src/lib.js
@@ -452,9 +452,7 @@ async function getItems(base64, customTextures = false, packs, cacheOnly = false
 
                 const boost = item.tag.ExtraAttributes.baseStatBoostPercentage;
 
-                item.lore += "<br><br>";
-
-                item.lore += boost == 50 ? helper.renderLore(`§7Dungeon Item Quality: §6${boost}/50%`) : helper.renderLore(`§7Dungeon Item Quality: §c${boost}/50%`);
+                item.lore += "<br><br>" + helper.renderLore(`§7Dungeon Item Quality: ${boost == 50 ? '§6' : '§c'}${boost}/50%`);
             }
 
             if(helper.hasPath(item, 'tag', 'ExtraAttributes', 'item_tier')){

--- a/src/lib.js
+++ b/src/lib.js
@@ -447,6 +447,20 @@ async function getItems(base64, customTextures = false, packs, cacheOnly = false
 
                 item.lore += "<br>" + helper.renderLore(`§7By: §c<a href="/stats/${spawnedFor}">${spawnedForUser.display_name}</a>`);
             }
+ 
+            if(helper.hasPath(item, 'tag', 'ExtraAttributes', 'baseStatBoostPercentage')){
+
+                const boost = item.tag.ExtraAttributes.baseStatBoostPercentage;
+
+                item.lore += "<br><br>" + helper.renderLore(`§7Dungeon Item Base Stat Boost: §c${boost}%`);
+            }
+
+            if(helper.hasPath(item, 'tag', 'ExtraAttributes', 'item_tier')){
+
+                const floor = item.tag.ExtraAttributes.item_tier;
+
+                item.lore += "<br>" + helper.renderLore(`§7Dungeon Floor: §c${floor}`);
+            }
         }
 
         let lore = lore_raw ? lore_raw.map(a => a = helper.getRawLore(a)) : [];

--- a/src/lib.js
+++ b/src/lib.js
@@ -452,14 +452,18 @@ async function getItems(base64, customTextures = false, packs, cacheOnly = false
 
                 const boost = item.tag.ExtraAttributes.baseStatBoostPercentage;
 
-                item.lore += "<br><br>" + helper.renderLore(`§7Dungeon Item Base Stat Boost: §c${boost}%`);
+                item.lore += "<br><br>";
+
+                item.lore += boost == 50 ? helper.renderLore(`§7Dungeon Item Quality: §6${boost}/50%`) : helper.renderLore(`§7Dungeon Item Quality: §c${boost}/50%`);
             }
 
             if(helper.hasPath(item, 'tag', 'ExtraAttributes', 'item_tier')){
 
                 const floor = item.tag.ExtraAttributes.item_tier;
 
-                item.lore += "<br>" + helper.renderLore(`§7Dungeon Floor: §c${floor}`);
+                item.lore += "<br>"
+
+                item.lore += helper.renderLore(`§7Obtained From: §bFloor ${floor}`);
             }
         }
 


### PR DESCRIPTION
For dungeon items with stat boosts and floor data, displays them at the bottom of the item lore.