### PR TITLE
make plus on VIP+ gold

### DIFF
--- a/src/helper.js
+++ b/src/helper.js
@@ -533,6 +533,9 @@ module.exports = {
         if(rankName == 'PIG+++')
             output.plusColor = 'b';
 
+        if(rankName == 'VIP_PLUS')
+             output.plusColor = '6';
+
         return output;
     },
 


### PR DESCRIPTION
## before:
![image](https://user-images.githubusercontent.com/44071655/113523875-c3e34e00-9578-11eb-96ee-d1d7a737cdef.png)
## after:
![image](https://user-images.githubusercontent.com/44071655/113523871-bc23a980-9578-11eb-824e-ab1c24f04f75.png)

this PR is the same as: SkyCryptWebsite/SkyCrypt#372
this PR fixes: SkyCryptWebsite/SkyCrypt#371

this PR was not tested on LeaPhant/skyblock-stats but was tested on nstringham/SkyCrypt so it should all work