### PR TITLE
use `name="ign"` for SkyCrypt interop

### DIFF
--- a/includes/header.ejs
+++ b/includes/header.ejs
@@ -14,7 +14,7 @@
         <a title="Patreon" target="_blank" rel="nofollow" href="https://patreon.com/LeaPhant" class="social-button patreon"><%= extra.donations.patreon %> Patrons<div class="social-icon"></div></a>
         <a title="Ko-fi" target="_blank" rel="nofollow" href="https://ko-fi.com/leaphant" class="social-button ko-fi"><%= extra.donations.kofi %>x Ko-fi<div class="social-icon"></div></a>
     <% } %>
-    <div id="search_user"><input placeholder="Enter username" <% if(page == 'index'){ %>tabindex="-1"<% } %> type="text" id="inp_search_user"></input><a href="#" <% if(page == 'index'){ %>tabindex="-1"<% } %> id="btn_search_user"></a></div>
+    <div id="search_user"><input placeholder="Enter username" <% if(page == 'index'){ %>tabindex="-1"<% } %> type="search" id="inp_search_user" name="ign" enterkeyhint="go" aria-label="username"><a href="#" <% if(page == 'index'){ %>tabindex="-1"<% } %> id="btn_search_user"></a></div>
     <a href="https://blacklivesmatters.carrd.co/" target="_blank" rel="nofollow" data-tippy-content="<strong>Black Lives Matter!</strong><br><br>Click for a collection of links on how to support the fight against racial inequality." class="blm-logo"></a>
 </header>
 <div id="info_box">

--- a/public/resources/css/index.css
+++ b/public/resources/css/index.css
@@ -12,6 +12,11 @@ html{
     overflow-x: hidden;
 }
 
+input[type="search"]::-webkit-search-cancel-button,
+input[type="search"]::-webkit-search-results-button{
+    -webkit-appearance: none;
+}
+
 .grecaptcha-badge{
     visibility: hidden;
 }

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -57,7 +57,7 @@
         <div id="enter_player_box_wrapper">
             <div id="enter_player_box">
                 <p>Show SkyBlock stats for</p>
-                <input <% if(player){ %> value="<%= player %>" <% }%> id="inp_enter_username" type="text" placeholder="Enter username">
+                <input <% if(player){ %> value="<%= player %>" <% }%> id="inp_enter_username" type="search" placeholder="Enter username" name="ign" enterkeyhint="go" aria-label="username">
                 <a href="<% if(player){ %>/stats/<%= player %><% }else{ %>#<% } %>" id="goto_target_username">Show me</a>
                 <!--<p>or take me to a <a href="/random/stats">random profile</a>.</p>-->
             </div>


### PR DESCRIPTION
This PR makes a few small changes to the username input fields to make it easier for people who want to view the same profiles on SkyCrypt and on SkyLea.

- change the input type from `text` to `search` this allows browsers to suggest recent searches to the user.
- set input name to `ign` this is to match SkyCrypt so the browser can suggest recent SkyCrypt searches in SkyLea and vice versa.
- add `enterkeyhint` and `aria-label` to improve accesablity
- remove icons that chrome and safari place onto `input[type="search"]`

Screenshot on Desktop Chrome
![image](https://user-images.githubusercontent.com/44071655/126316745-7d50d72b-19dc-4d05-b8c5-bd366c464283.png)
