### PR TITLE
cache for 30 days not 30000 days

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -42,7 +42,7 @@ async function main(){
     await mongo.connect();
     const db = mongo.db(credentials.dbName);
 
-    const CACHE_DURATION = 30 * 24 * 60 * 60 * 1000; // 30 days
+    const CACHE_DURATION = 30 * 24 * 60 * 60; // 30 days
 
     const cachePath = path.resolve(__dirname, '../cache');
 
@@ -59,7 +59,7 @@ async function main(){
     app.locals.moment = moment;
     app.use(bodyParser.urlencoded({ extended: true }));
     app.set('view engine', 'ejs');
-    app.use(express.static('public', { maxAge: CACHE_DURATION }));
+    app.use(express.static('public', { maxAge: CACHE_DURATION * 1000 }));
 
     app.use(session({
         secret: credentials.session_secret,


### PR DESCRIPTION
this PR fixes a problem caused by HTTP wanting seconds and express wanting milliseconds and app.js giving them both the same number.

this problem was fixed in SkyCrypt in https://github.com/SkyCryptWebsite/SkyCrypt/pull/735